### PR TITLE
Added VTK file output support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ run/unit-cell-creator
 MPI-compute-times
 MPI-wait-times
 #EOF
+.vs/

--- a/Vampire.sln
+++ b/Vampire.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Express 2013 for Windows Desktop
-VisualStudioVersion = 12.0.31101.0
+# Visual Studio 15
+VisualStudioVersion = 15.0.27428.2037
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Vampire", "Vampire.vcxproj", "{2B6C253A-E90C-4912-9C4A-1FBCC22D734A}"
 EndProject
@@ -18,5 +18,8 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {C86C4AA5-93BD-4962-AC1B-3C3EBF4E293D}
 	EndGlobalSection
 EndGlobal

--- a/Vampire.vcxproj
+++ b/Vampire.vcxproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -145,18 +145,19 @@
     <ProjectGuid>{2B6C253A-E90C-4912-9C4A-1FBCC22D734A}</ProjectGuid>
     <RootNamespace>VampireWin</RootNamespace>
     <ProjectName>Vampire</ProjectName>
+    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>

--- a/Vampire.vcxproj
+++ b/Vampire.vcxproj
@@ -200,6 +200,8 @@
       <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions);WIN_COMPILE;M_PI=3.145926;_CRT_SECURE_NO_WARNINGS;</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>.\src\qvoronoi;.\hdr;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <ObjectFileName>$(IntDir)/%(RelativeDir)/</ObjectFileName>
+      <MinimalRebuild>false</MinimalRebuild>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>

--- a/hdr/vio.hpp
+++ b/hdr/vio.hpp
@@ -101,6 +101,7 @@ namespace vout{
    extern bool gnuplot_array_format;
 	
 	extern bool output_atoms_config;
+	extern bool output_atoms_config_vtk;
 	extern int output_atoms_config_rate;
 	
 	extern double atoms_output_min[3];

--- a/hdr/vio.hpp
+++ b/hdr/vio.hpp
@@ -103,6 +103,7 @@ namespace vout{
 	extern bool output_atoms_config;
 	extern bool output_atoms_config_vtk;
 	extern int output_atoms_config_rate;
+	extern int output_atoms_vtk_rate;
 	
 	extern double atoms_output_min[3];
 	extern double atoms_output_max[3];

--- a/input_vtk
+++ b/input_vtk
@@ -7,17 +7,17 @@
 #------------------------------------------
 # Creation attributes:
 #------------------------------------------
-create:crystal-structure=sc
+create:crystal-structure=bcc
 create:ellipsoid
 
 #------------------------------------------
 # System Dimensions:
 #------------------------------------------
 dimensions:unit-cell-size = 3.54 !A
-# dimensions:system-size-x = 10 !nm
-# dimensions:system-size-y = 10 !nm
-# dimensions:system-size-z = 10 !nm
-dimensions:particle-size= 10 !nm
+# dimensions:system-size-x = 5 !nm
+# dimensions:system-size-y = 5 !nm
+# dimensions:system-size-z = 5 !nm
+dimensions:particle-size= 5 !nm
 dimensions:particle-shape-factor-x = 1
 dimensions:particle-shape-factor-y = 0.8
 dimensions:particle-shape-factor-z = 0.2
@@ -30,33 +30,38 @@ material:file=mat/Fe.mat
 #------------------------------------------
 # Simulation attributes:
 #------------------------------------------
-sim:temperature=300.0
 
-sim:time-step=1.0E-10
-sim:time-steps-increment=10
-sim:total-time-steps=10000
+# sim:time-step=1.0E-10
+# sim:total-time-steps=10000
 
-sim:program=static-hysteresis-loop
+sim:program=hysteresis-loop
 sim:integrator=llg-heun
 # sim:integrator=monte-carlo
-sim:loop-time-steps=100000
+
+sim:loop-time-steps=10000
+sim:time-steps-increment=10000
 sim:equilibration-time-steps=10000
-sim:maximum-applied-field-strength=3.0 !T
-sim:applied-field-strength-increment=0.1 !T
+
+sim:time-step=1e-16
+sim:temperature=300.0
 sim:applied-field-unit-vector= 1,0,0
+sim:maximum-applied-field-strength=3.0 !T
+sim:minimum-applied-field-strength=-3.0 !T
+sim:applied-field-strength-increment=0.1 !T
+
 
 #------------------------------------------
 # data output
 #------------------------------------------
-#output:real-time
+output:real-time
 #output:temperature
 config:atoms
-config:atoms-output-rate=10
+config:atoms-output-rate=1
 
 output:applied-field-strength
 output:applied-field-unit-vector
 output:magnetisation
-#output:output-rate = 1000
+# output:output-rate = 1000
 
 screen:time-steps
 screen:applied-field-strength

--- a/input_vtk
+++ b/input_vtk
@@ -8,42 +8,56 @@
 # Creation attributes:
 #------------------------------------------
 create:crystal-structure=sc
+create:ellipsoid
 
 #------------------------------------------
 # System Dimensions:
 #------------------------------------------
 dimensions:unit-cell-size = 3.54 !A
-dimensions:system-size-x = 10 !nm
-dimensions:system-size-y = 10 !nm
-dimensions:system-size-z = 10 !nm
+# dimensions:system-size-x = 10 !nm
+# dimensions:system-size-y = 10 !nm
+# dimensions:system-size-z = 10 !nm
+dimensions:particle-size= 10 !nm
+dimensions:particle-shape-factor-x = 1
+dimensions:particle-shape-factor-y = 0.8
+dimensions:particle-shape-factor-z = 0.2
 
 #------------------------------------------
 # Material Files:
 #------------------------------------------
-material:file=Fe.mat
+material:file=mat/Fe.mat
 
 #------------------------------------------
 # Simulation attributes:
 #------------------------------------------
 sim:temperature=300.0
+
+sim:time-step=1.0E-10
 sim:time-steps-increment=10
 sim:total-time-steps=10000
-sim:time-step=1.0E-15
 
-#------------------------------------------
-# Program and integrator details
-#------------------------------------------
-sim:program=benchmark
+sim:program=static-hysteresis-loop
 sim:integrator=llg-heun
+# sim:integrator=monte-carlo
+sim:loop-time-steps=100000
+sim:equilibration-time-steps=10000
+sim:maximum-applied-field-strength=3.0 !T
+sim:applied-field-strength-increment=0.1 !T
+sim:applied-field-unit-vector= 1,0,0
 
 #------------------------------------------
 # data output
 #------------------------------------------
-output:real-time
-output:temperature
+#output:real-time
+#output:temperature
+config:atoms
+config:atoms-output-rate=10
+
+output:applied-field-strength
+output:applied-field-unit-vector
 output:magnetisation
-output:magnetisation-length
-output:output-rate = 1000
+#output:output-rate = 1000
 
 screen:time-steps
-screen:magnetisation-length
+screen:applied-field-strength
+screen:magnetisation

--- a/input_vtk
+++ b/input_vtk
@@ -1,0 +1,49 @@
+#------------------------------------------
+# Sample vampire input file to perform
+# benchmark calculation for v4.0
+#
+#------------------------------------------
+
+#------------------------------------------
+# Creation attributes:
+#------------------------------------------
+create:crystal-structure=sc
+
+#------------------------------------------
+# System Dimensions:
+#------------------------------------------
+dimensions:unit-cell-size = 3.54 !A
+dimensions:system-size-x = 10 !nm
+dimensions:system-size-y = 10 !nm
+dimensions:system-size-z = 10 !nm
+
+#------------------------------------------
+# Material Files:
+#------------------------------------------
+material:file=Fe.mat
+
+#------------------------------------------
+# Simulation attributes:
+#------------------------------------------
+sim:temperature=300.0
+sim:time-steps-increment=10
+sim:total-time-steps=10000
+sim:time-step=1.0E-15
+
+#------------------------------------------
+# Program and integrator details
+#------------------------------------------
+sim:program=benchmark
+sim:integrator=llg-heun
+
+#------------------------------------------
+# data output
+#------------------------------------------
+output:real-time
+output:temperature
+output:magnetisation
+output:magnetisation-length
+output:output-rate = 1000
+
+screen:time-steps
+screen:magnetisation-length

--- a/input_vtk
+++ b/input_vtk
@@ -14,10 +14,10 @@ create:ellipsoid
 # System Dimensions:
 #------------------------------------------
 dimensions:unit-cell-size = 3.54 !A
-# dimensions:system-size-x = 5 !nm
-# dimensions:system-size-y = 5 !nm
-# dimensions:system-size-z = 5 !nm
-dimensions:particle-size= 5 !nm
+dimensions:system-size-x = 25 !nm
+dimensions:system-size-y = 25 !nm
+dimensions:system-size-z = 25 !nm
+dimensions:particle-size= 25 !nm
 dimensions:particle-shape-factor-x = 1
 dimensions:particle-shape-factor-y = 0.8
 dimensions:particle-shape-factor-z = 0.2
@@ -54,9 +54,11 @@ sim:applied-field-strength-increment=0.1 !T
 # data output
 #------------------------------------------
 output:real-time
-#output:temperature
-config:atoms
-config:atoms-output-rate=1
+# output:temperature
+config:vtk
+config:vtk-output-rate=1
+# config:atoms-output-rate-vtk=1
+# config:atoms-output-rate=1
 
 output:applied-field-strength
 output:applied-field-unit-vector

--- a/input_vtk
+++ b/input_vtk
@@ -8,19 +8,17 @@
 # Creation attributes:
 #------------------------------------------
 create:crystal-structure=bcc
-create:ellipsoid
+# create:ellipsoid
+create:cylinder
 
 #------------------------------------------
 # System Dimensions:
 #------------------------------------------
 dimensions:unit-cell-size = 3.54 !A
-dimensions:system-size-x = 25 !nm
-dimensions:system-size-y = 25 !nm
-dimensions:system-size-z = 25 !nm
-dimensions:particle-size= 25 !nm
-dimensions:particle-shape-factor-x = 1
-dimensions:particle-shape-factor-y = 0.8
-dimensions:particle-shape-factor-z = 0.2
+dimensions:system-size-x = 10 !nm
+dimensions:system-size-y = 10 !nm
+dimensions:system-size-z = 1 !nm
+dimensions:particle-size= 10 !nm
 
 #------------------------------------------
 # Material Files:
@@ -43,7 +41,7 @@ sim:time-steps-increment=10000
 sim:equilibration-time-steps=10000
 
 sim:time-step=1e-16
-sim:temperature=300.0
+sim:temperature=0.0
 sim:applied-field-unit-vector= 1,0,0
 sim:maximum-applied-field-strength=3.0 !T
 sim:minimum-applied-field-strength=-3.0 !T

--- a/mat/Fe.mat
+++ b/mat/Fe.mat
@@ -1,0 +1,20 @@
+#===================================================
+# Vampire material file for Fe
+#===================================================
+#
+# P. D. Murray 2018-04-14
+#
+#---------------------------------------------------
+# Number of Materials
+#---------------------------------------------------
+material:num-materials=1
+#---------------------------------------------------
+# Material 0 Iron Generic
+#---------------------------------------------------
+material[0]:material-name="Fe"
+material[0]:damping-constant=0.1
+material[0]:atomic-spin-moment=1.92 !muB
+material[0]:uniaxial-anisotropy-constant=-8.07246e-24
+material[0]:material-element=Fe
+material[0]:initial-spin-direction=0,0,1
+material[0]:exchange-matrix[0]=12e-21

--- a/mat/Fe.mat
+++ b/mat/Fe.mat
@@ -11,10 +11,10 @@ material:num-materials=1
 #---------------------------------------------------
 # Material 0 Iron Generic
 #---------------------------------------------------
-material[0]:material-name="Fe"
-material[0]:damping-constant=0.1
-material[0]:atomic-spin-moment=1.92 !muB
-material[0]:uniaxial-anisotropy-constant=-8.07246e-24
-material[0]:material-element=Fe
-material[0]:initial-spin-direction=0,0,1
-material[0]:exchange-matrix[0]=12e-21
+material[1]:material-name="Fe"
+material[1]:damping-constant=0.1
+material[1]:atomic-spin-moment=1.92 !muB
+material[1]:uniaxial-anisotropy-constant=-8.07246e-24
+material[1]:material-element=Fe
+material[1]:initial-spin-direction=1,0.1,0
+material[1]:exchange-matrix[1]=12e-21

--- a/src/utility/vconfig.cpp
+++ b/src/utility/vconfig.cpp
@@ -88,7 +88,7 @@ namespace vout{
    // function headers
    void atoms();
    void atoms_vtk();
-   void calculate_total_atoms();
+   void build_local_atom_list();
    void write_atom_coordinates(std::ofstream&);
    void write_atom_spins(std::ofstream&);
    void write_atom_materials(std::ofstream&);
@@ -258,45 +258,7 @@ void config(){
 
 /// @brief VTK Atomistic output function
 ///
-/// @details Outputs vtk-formatted data snapshot for visualisation  
-///
-///	#------------------------------------------------------
-///	# VTK Atomistic spin configuration file for vampire
-///	#------------------------------------------------------
-///	# Date: xx/xx/xxxx xx.xx.xx
-///	#------------------------------------------------------
-///	Number of spins: $n_spins
-///	System dimensions: $max_x $max_y $max_z
-///	Coordinates-file: $coord_file
-///	Time: $t
-///	Field: $H
-///	Temperature: $T
-///	Magnetisation: $mx $my $mz
-///	Number of Materials: $n_mat
-///	Material Properties 1:	$mu_s	$mmx $mmy $mmz $mm
-///	Material Properties 2:	$mu_s	$mmx $mmy $mmz ...
-///	#------------------------------------------------------
-///	Number of spin files: $n_files
-///	atoms-000ID000-00CPU0.cfg
-///	atoms-000ID000-00CPU1.cfg
-///	atoms-000ID000-00CPU2.cfg
-///	#------------------------------------------------------
-///	Number of local spins: $n_loc_spins
-///	$sx $sy $sz
-///	$sx $sy ...
-///
-/// @section License
-/// Use of this code, either in source or compiled form, is subject to license from the authors.
-/// Copyright \htmlonly &copy \endhtmlonly Richard Evans, 2009-2011. All Rights Reserved.
-///
-/// @section Information
-/// @author  Peyton Murray
-/// @version 1.0
-/// @date    2018-04-15
-///
-/// @internal
-///	Created:		2018-04-15
-///	Revision:	  ---
+/// @details Outputs vtk-formatted data snapshot for visualisation. See www.vtk.org for more info. 
 ///=====================================================================================
 ///
    void atoms_vtk() {
@@ -311,7 +273,7 @@ void config(){
 	   #endif
 
 	   // Calculate the total number of local atoms. Needed for output, particularly for MPI.
-	   calculate_total_atoms();
+	   build_local_atom_list();
 
 	   // Set local output filename
 	   std::stringstream file_sstr;
@@ -348,17 +310,19 @@ void config(){
 	   // Write atom spins to data part of vtk file
 	   write_atom_spins(cfg_file_ofstr);
 
-	   // Write atom type to data part of vtk file
-	   //cfg_file_ofstr << "SCALARS ELEMENT char\n";
-	   //cfg_file_ofstr << "LOOKUP_TABLE default\n";
-	   //write_atom_materials(cfg_file_ofstr);
-
 	   cfg_file_ofstr.close();
 	   output_atoms_vtk_file_counter++;
 	   return;
    }
 
-   void calculate_total_atoms() {
+
+   /// @brief Builds the local atom list
+   ///
+   /// @details Updates vout::total_output_atoms and vout::local_output_atom_list
+   /// with the local atoms.
+   ///=====================================================================================
+   ///
+   void build_local_atom_list() {
 	   #ifdef MPICF
 	   const int num_atoms = vmpi::num_core_atoms + vmpi::num_bdry_atoms;
 	   #else
@@ -407,6 +371,15 @@ void config(){
 	   return;
    }
 
+   /// @brief Write atom coordinates to an output filestream.
+   ///
+   /// @details Outputs atomic coordinates, one on each line.:
+   /// x1 y1 z1
+   /// x2 y2 z2
+   /// x3 y3 z3
+   ///   ...
+   ///=====================================================================================
+   ///
    void write_atom_coordinates(std::ofstream& filestream) {
 
 	   if (err::check == true) std::cout << "vout::write_atom_coordinates_vtk has been called" << std::endl;
@@ -426,6 +399,15 @@ void config(){
 	   else throw std::runtime_error("vout::write_atom_coordinates_vtk was called, but input filestream was not open.");
    }
 
+   /// @brief Write atom spins to an output filestream
+   ///
+   /// @details Outputs atomic spins, one on each line.:
+   /// s1x s1y s1z
+   /// s2x s2y s2z
+   /// s3x s3y s3z
+   ///   ... 
+   ///=====================================================================================
+   ///
    void write_atom_spins(std::ofstream& filestream) {
 
 	   if (err::check == true) std::cout << "vout::write_atom_spins has been called" << std::endl;
@@ -443,6 +425,15 @@ void config(){
 	   else throw std::runtime_error("vout::write_atom_spins was called, but input filestream was not open.");
    }
 
+   /// @brief Write atom material to an output filestream
+   ///
+   /// @details Outputs atomic material, one on each line.:
+   /// a1
+   /// a2
+   /// a3
+   ///   ... 
+   ///=====================================================================================
+   ///
    void write_atom_materials(std::ofstream& filestream) {
 
 	   if (err::check == true) std::cout << "vout::write_atom_materials has been called" << std::endl;

--- a/src/utility/vconfig.cpp
+++ b/src/utility/vconfig.cpp
@@ -65,6 +65,7 @@
 namespace vout{
 
    bool output_atoms_config=false;
+   bool output_atoms_config_vtk = false;
    int output_atoms_config_rate=1000;
    int output_atoms_file_counter=0;
    int output_rate_counter=0;
@@ -119,6 +120,11 @@ void config(){
    if((vout::output_cells_config==true) && (vout::output_rate_counter%output_cells_config_rate==0)){
       if(output_cells_file_counter==0) vout::cells_coords();
       vout::cells();
+   }
+
+   // atomic spins output - vtk file format
+   if ((vout::output_atoms_config_vtk == true) && (vout::output_rate_counter%output_cells_config_rate == 0)) {
+	   vout::atoms_vtk();
    }
 
    // increment rate counter
@@ -240,6 +246,126 @@ void config(){
       cfg_file_ofstr.close();
 
       output_atoms_file_counter++;
+
+   }
+
+/// @brief VTK Atomistic output function
+///
+/// @details Outputs vtk-formatted data snapshot for visualisation  
+///
+///	#------------------------------------------------------
+///	# VTK Atomistic spin configuration file for vampire
+///	#------------------------------------------------------
+///	# Date: xx/xx/xxxx xx.xx.xx
+///	#------------------------------------------------------
+///	Number of spins: $n_spins
+///	System dimensions: $max_x $max_y $max_z
+///	Coordinates-file: $coord_file
+///	Time: $t
+///	Field: $H
+///	Temperature: $T
+///	Magnetisation: $mx $my $mz
+///	Number of Materials: $n_mat
+///	Material Properties 1:	$mu_s	$mmx $mmy $mmz $mm
+///	Material Properties 2:	$mu_s	$mmx $mmy $mmz ...
+///	#------------------------------------------------------
+///	Number of spin files: $n_files
+///	atoms-000ID000-00CPU0.cfg
+///	atoms-000ID000-00CPU1.cfg
+///	atoms-000ID000-00CPU2.cfg
+///	#------------------------------------------------------
+///	Number of local spins: $n_loc_spins
+///	$sx $sy $sz
+///	$sx $sy ...
+///
+/// @section License
+/// Use of this code, either in source or compiled form, is subject to license from the authors.
+/// Copyright \htmlonly &copy \endhtmlonly Richard Evans, 2009-2011. All Rights Reserved.
+///
+/// @section Information
+/// @author  Richard Evans, richard.evans@york.ac.uk
+/// @version 1.0
+/// @date    30/05/2011
+///
+/// @internal
+///	Created:		30/05/2011
+///	Revision:	  ---
+///=====================================================================================
+///
+   void atoms_vtk() {
+
+	   // check calling of routine if error checking is activated
+	   if (err::check == true) { std::cout << "vout::atoms_vtk has been called" << std::endl; }
+
+	   #ifdef MPICF
+	   const int num_atoms = vmpi::num_core_atoms + vmpi::num_bdry_atoms;
+	   #else
+	   const int num_atoms = atoms::num_atoms;
+	   #endif
+
+	   // Set local output filename
+	   std::stringstream file_sstr;
+	   file_sstr << "spins-";
+	   // Set CPUID on non-root process
+	   if (vmpi::my_rank != 0) {
+		   file_sstr << std::setfill('0') << std::setw(5) << vmpi::my_rank << "-";
+	   }
+	   file_sstr << std::setfill('0') << std::setw(8) << output_atoms_file_counter << ".vtk";
+
+	   std::string cfg_file = file_sstr.str();
+
+	   // Output informative message to log file
+	   zlog << zTs() << "Outputting vtk configuration file " << cfg_file << " to disk" << std::endl;
+
+	   // Declare and open output file
+	   std::ofstream cfg_file_ofstr;
+	   cfg_file_ofstr.open(cfg_file.c_str());
+
+	   // Output masterfile header on root process
+	   if (vmpi::my_rank == 0) {
+		   // Get system date
+		   time_t rawtime = time(NULL);
+		   struct tm * timeinfo = localtime(&rawtime);
+
+		   cfg_file_ofstr << "#------------------------------------------------------" << std::endl;
+		   cfg_file_ofstr << "# Atomistic spin configuration file for vampire" << std::endl;
+		   cfg_file_ofstr << "#------------------------------------------------------" << std::endl;
+		   cfg_file_ofstr << "# Date: " << asctime(timeinfo);
+		   cfg_file_ofstr << "#------------------------------------------------------" << std::endl;
+		   cfg_file_ofstr << "Number of spins: " << vout::total_output_atoms << std::endl;
+		   cfg_file_ofstr << "System dimensions:" << cs::system_dimensions[0] << "\t" << cs::system_dimensions[1] << "\t" << cs::system_dimensions[2] << std::endl;
+		   cfg_file_ofstr << "Coordinates-file: atoms-coord.cfg" << std::endl;
+		   cfg_file_ofstr << "Time: " << double(sim::time)*mp::dt_SI << std::endl;
+		   cfg_file_ofstr << "Field: " << sim::H_applied << std::endl;
+		   cfg_file_ofstr << "Temperature: " << sim::temperature << std::endl;
+		   cfg_file_ofstr << "Magnetisation: " << stats::system_magnetization.output_normalized_magnetization() << std::endl;
+		   cfg_file_ofstr << "Number of Materials: " << mp::num_materials << std::endl;
+		   for (int mat = 0; mat<mp::num_materials; mat++) {
+			   cfg_file_ofstr << mp::material[mat].mu_s_SI << std::endl;
+		   }
+		   cfg_file_ofstr << "#------------------------------------------------------" << std::endl;
+		   cfg_file_ofstr << "Number of spin files: " << vmpi::num_processors - 1 << std::endl;
+		   for (int p = 1; p<vmpi::num_processors; p++) {
+			   std::stringstream cfg_sstr;
+			   cfg_sstr << "atoms-" << std::setfill('0') << std::setw(5) << p << "-" << std::setfill('0') << std::setw(8) << output_atoms_file_counter << ".cfg";
+			   cfg_file_ofstr << cfg_sstr.str() << std::endl;
+		   }
+		   cfg_file_ofstr << "#------------------------------------------------------" << std::endl;
+	   }
+
+	   // Everyone now outputs their atom list
+	   cfg_file_ofstr << vout::local_output_atom_list.size() << std::endl;
+	   for (int i = 0; i<vout::local_output_atom_list.size(); i++) {
+		   const int atom = vout::local_output_atom_list[i];
+		   cfg_file_ofstr << atoms::x_spin_array[atom] << "\t" << atoms::y_spin_array[atom] << "\t" << atoms::z_spin_array[atom] << std::endl;
+	   }
+
+	   cfg_file_ofstr.close();
+
+	   output_atoms_file_counter++;
+
+
+
 
    }
 

--- a/src/utility/vio.cpp
+++ b/src/utility/vio.cpp
@@ -2169,6 +2169,12 @@ int match_config(string const word, string const value, int const line){
       return EXIT_SUCCESS;
    }
    //-----------------------------------------
+   std::string test = "vtk";
+   if (word == test) {
+	   vout::output_atoms_config_vtk = true;
+	   return EXIT_SUCCESS;
+   }
+   //--------------------------------------------------------------------
    test="atoms-output-rate";
    if(word==test){
       int i=atoi(value.c_str());
@@ -2601,13 +2607,6 @@ int match_vout_list(string const word, string const value, int const line, std::
       vout::output_rate=r;
       return EXIT_SUCCESS;
    }
-   //--------------------------------------------------------------------
-   test = "vtk";
-   if (word == test){
-	   output_list.push_back(61);
-	   return EXIT_SUCCESS;
-   }
-   //--------------------------------------------------------------------
 
    //--------------------------------------------------------------------
    // keyword not found
@@ -4140,6 +4139,10 @@ namespace vout{
 		stream << vmpi::AverageComputeTime+vmpi::AverageWaitTime << "\t" << vmpi::AverageComputeTime << "\t" << vmpi::AverageWaitTime;
 		stream << "\t" << vmpi::MaximumComputeTime << "\t" << vmpi::MaximumWaitTime << "\t";
 	}
+	// Output Function 61
+	void vtk_magnetization(std::ostream& stream) {
+		// Fill in later
+	}
 	
 	// Data output wrapper function
 	void data(){
@@ -4188,144 +4191,147 @@ namespace vout{
 
 		// Output data to output
       if(vmpi::my_rank==0){
-		for(unsigned int item=0;item<file_output_list.size();item++){
-			switch(file_output_list[item]){
-				case 0:
-					vout::time(zmag);
-					break;
-				case 1:
-					vout::real_time(zmag);
-					break;
-				case 2:
-					vout::temperature(zmag);
-					break;
-				case 3:
-					vout::Happ(zmag);
-					break;
-				case 4:
-					vout::Hvec(zmag);
-					break;
-				case 5:
-					vout::mvec(zmag);
-					break;
-				case 6:
-					vout::magm(zmag);
-					break;
-				case 7:
-					vout::mean_magm(zmag);
-					break;
-				case 8:
-					vout::mat_mvec(zmag);
-					break;
-				case 9:
-					vout::mat_mean_magm(zmag);
-					break;
-				case 12:
-					vout::mdoth(zmag);
-					break;
-				case 14:
-					vout::systorque(zmag);
-					break;
-				case 15:
-					vout::mean_systorque(zmag);
-					break;
-				case 16:
-					vout::constraint_phi(zmag);
-					break;
-				case 17:
-					vout::constraint_theta(zmag);
-					break;
-				case 18:
-					vout::material_constraint_phi(zmag);
-					break;
-				case 19:
-					vout::material_constraint_theta(zmag);
-					break;
-				case 20:
-					vout::material_mean_systorque(zmag);
-					break;
-				case 21:
-					vout::mean_system_susceptibility(zmag);
-					break;
-				case 22:
-					vout::phonon_temperature(zmag);
-					break;
-				case 23:
-					vout::material_temperature(zmag);
-					break;
-				case 24:
-					vout::material_applied_field_strength(zmag);
-					break;
-				case 25:
-					vout::material_fmr_field_strength(zmag);
-					break;
-				case 26:
-					vout::mat_mdoth(zmag);
-					break;
-            case 27:
-               vout::total_energy(zmag);
-               break;
-            case 28:
-               vout::mean_total_energy(zmag);
-               break;
-            case 29:
-               vout::total_anisotropy_energy(zmag);
-               break;
-            case 30:
-               vout::mean_total_anisotropy_energy(zmag);
-               break;
-            case 31:
-               vout::total_cubic_anisotropy_energy(zmag);
-               break;
-            case 32:
-               vout::mean_total_cubic_anisotropy_energy(zmag);
-               break;
-            case 33:
-               vout::total_surface_anisotropy_energy(zmag);
-               break;
-            case 34:
-               vout::mean_total_surface_anisotropy_energy(zmag);
-               break;
-            case 35:
-               vout::total_exchange_energy(zmag);
-               break;
-            case 36:
-               vout::mean_total_exchange_energy(zmag);
-               break;
-            case 37:
-               vout::total_applied_field_energy(zmag);
-               break;
-            case 38:
-               vout::mean_total_applied_field_energy(zmag);
-               break;
-            case 39:
-               vout::total_magnetostatic_energy(zmag);
-               break;
-            case 40:
-               vout::mean_total_magnetostatic_energy(zmag);
-               break;
-            case 41:
-               vout::total_so_anisotropy_energy(zmag);
-               break;
-            case 42:
-               vout::mean_total_so_anisotropy_energy(zmag);
-               break;
-            case 43:
-               vout::height_mvec(zmag);
-               break;
-            case 44:
-               vout::material_height_mvec(zmag);
-               break;
-            case 45:
-               vout::height_mvec_actual(zmag);
-               break;
-            case 46:
-               vout::material_height_mvec_actual(zmag);
-               break;
-            case 60:
-					vout::MPITimings(zmag);
-					break;
-			}
+		  for (unsigned int item = 0; item < file_output_list.size(); item++) {
+			  switch (file_output_list[item]) {
+			  case 0:
+				  vout::time(zmag);
+				  break;
+			  case 1:
+				  vout::real_time(zmag);
+				  break;
+			  case 2:
+				  vout::temperature(zmag);
+				  break;
+			  case 3:
+				  vout::Happ(zmag);
+				  break;
+			  case 4:
+				  vout::Hvec(zmag);
+				  break;
+			  case 5:
+				  vout::mvec(zmag);
+				  break;
+			  case 6:
+				  vout::magm(zmag);
+				  break;
+			  case 7:
+				  vout::mean_magm(zmag);
+				  break;
+			  case 8:
+				  vout::mat_mvec(zmag);
+				  break;
+			  case 9:
+				  vout::mat_mean_magm(zmag);
+				  break;
+			  case 12:
+				  vout::mdoth(zmag);
+				  break;
+			  case 14:
+				  vout::systorque(zmag);
+				  break;
+			  case 15:
+				  vout::mean_systorque(zmag);
+				  break;
+			  case 16:
+				  vout::constraint_phi(zmag);
+				  break;
+			  case 17:
+				  vout::constraint_theta(zmag);
+				  break;
+			  case 18:
+				  vout::material_constraint_phi(zmag);
+				  break;
+			  case 19:
+				  vout::material_constraint_theta(zmag);
+				  break;
+			  case 20:
+				  vout::material_mean_systorque(zmag);
+				  break;
+			  case 21:
+				  vout::mean_system_susceptibility(zmag);
+				  break;
+			  case 22:
+				  vout::phonon_temperature(zmag);
+				  break;
+			  case 23:
+				  vout::material_temperature(zmag);
+				  break;
+			  case 24:
+				  vout::material_applied_field_strength(zmag);
+				  break;
+			  case 25:
+				  vout::material_fmr_field_strength(zmag);
+				  break;
+			  case 26:
+				  vout::mat_mdoth(zmag);
+				  break;
+			  case 27:
+				  vout::total_energy(zmag);
+				  break;
+			  case 28:
+				  vout::mean_total_energy(zmag);
+				  break;
+			  case 29:
+				  vout::total_anisotropy_energy(zmag);
+				  break;
+			  case 30:
+				  vout::mean_total_anisotropy_energy(zmag);
+				  break;
+			  case 31:
+				  vout::total_cubic_anisotropy_energy(zmag);
+				  break;
+			  case 32:
+				  vout::mean_total_cubic_anisotropy_energy(zmag);
+				  break;
+			  case 33:
+				  vout::total_surface_anisotropy_energy(zmag);
+				  break;
+			  case 34:
+				  vout::mean_total_surface_anisotropy_energy(zmag);
+				  break;
+			  case 35:
+				  vout::total_exchange_energy(zmag);
+				  break;
+			  case 36:
+				  vout::mean_total_exchange_energy(zmag);
+				  break;
+			  case 37:
+				  vout::total_applied_field_energy(zmag);
+				  break;
+			  case 38:
+				  vout::mean_total_applied_field_energy(zmag);
+				  break;
+			  case 39:
+				  vout::total_magnetostatic_energy(zmag);
+				  break;
+			  case 40:
+				  vout::mean_total_magnetostatic_energy(zmag);
+				  break;
+			  case 41:
+				  vout::total_so_anisotropy_energy(zmag);
+				  break;
+			  case 42:
+				  vout::mean_total_so_anisotropy_energy(zmag);
+				  break;
+			  case 43:
+				  vout::height_mvec(zmag);
+				  break;
+			  case 44:
+				  vout::material_height_mvec(zmag);
+				  break;
+			  case 45:
+				  vout::height_mvec_actual(zmag);
+				  break;
+			  case 46:
+				  vout::material_height_mvec_actual(zmag);
+				  break;
+			  case 60:
+				  vout::MPITimings(zmag);
+				  break;
+			  case 61:
+				  vout::vtk_magnetization(zmag);
+				break;
+			  }
 		}
 		// Carriage return
 		if(file_output_list.size()>0) zmag << std::endl;

--- a/src/utility/vio.cpp
+++ b/src/utility/vio.cpp
@@ -2601,6 +2601,13 @@ int match_vout_list(string const word, string const value, int const line, std::
       vout::output_rate=r;
       return EXIT_SUCCESS;
    }
+   //--------------------------------------------------------------------
+   test = "vtk";
+   if (word == test){
+	   output_list.push_back(61);
+	   return EXIT_SUCCESS;
+   }
+   //--------------------------------------------------------------------
 
    //--------------------------------------------------------------------
    // keyword not found

--- a/src/utility/vio.cpp
+++ b/src/utility/vio.cpp
@@ -4139,10 +4139,6 @@ namespace vout{
 		stream << vmpi::AverageComputeTime+vmpi::AverageWaitTime << "\t" << vmpi::AverageComputeTime << "\t" << vmpi::AverageWaitTime;
 		stream << "\t" << vmpi::MaximumComputeTime << "\t" << vmpi::MaximumWaitTime << "\t";
 	}
-	// Output Function 61
-	void vtk_magnetization(std::ostream& stream) {
-		// Fill in later
-	}
 	
 	// Data output wrapper function
 	void data(){
@@ -4328,9 +4324,6 @@ namespace vout{
 			  case 60:
 				  vout::MPITimings(zmag);
 				  break;
-			  case 61:
-				  vout::vtk_magnetization(zmag);
-				break;
 			  }
 		}
 		// Carriage return

--- a/src/utility/vio.cpp
+++ b/src/utility/vio.cpp
@@ -2169,9 +2169,17 @@ int match_config(string const word, string const value, int const line){
       return EXIT_SUCCESS;
    }
    //-----------------------------------------
-   std::string test = "vtk";
+   test = "vtk";
    if (word == test) {
 	   vout::output_atoms_config_vtk = true;
+	   return EXIT_SUCCESS;
+   }
+   //--------------------------------------------------------------------
+   test = "vtk-output-rate";
+   if (word == test) {
+	   int i=atoi(value.c_str());
+	   check_for_valid_int(i, word, line, prefix, 1, 1000000, "input", "1 - 1,000,000");
+	   vout::output_atoms_vtk_rate = i;
 	   return EXIT_SUCCESS;
    }
    //--------------------------------------------------------------------


### PR DESCRIPTION
I've always liked using [Paraview][paraview] for viewing micromagnetic simulations, so I added two new input file commands which allow for spins to be written in VTK file format:

* `config:vtk` works the same way as `config:atoms`, and enables the spins to be written to files formatted according to the VTK file spec.
* `config:vtk-output-rate` changes the rate at which the files are written, as a multiple of `sim:time-steps-increment`.

@richard-evans, I noticed that the `develop` branch is far behind `master` - is `master` still the right branch to submit this pull request to?

[paraview]: https://www.paraview.org