### PR TITLE
Swapped cusp spmv for cusparse spmv.

### DIFF
--- a/src/cuda/makefile
+++ b/src/cuda/makefile
@@ -41,7 +41,8 @@ CUDA_MATRIX_TYPE = CSR
 #CUDA_MATRIX_TYPE = DIA
 #CUDA_MATRIX_TYPE = ELL
 
-CUDA_CFLAGS= -O3 -I./hdr/cusplibrary-0.5.1 -I./hdr -DCUDA $(CUDA_ARCH) --use_fast_math -ftz=true -std=c++11
+#CUDA_CFLAGS= -O3 -I./hdr/cusplibrary-0.5.1 -I./hdr -DCUDA $(CUDA_ARCH) --use_fast_math -ftz=true -std=c++11
+CUDA_CFLAGS= -O3 -I./hdr -DCUDA $(CUDA_ARCH) --use_fast_math -ftz=true -std=c++11
 
 $(CUDA_OBJECTS): obj/%.o: src/%.cu
 	$(NVCC) $< -c -o $@ $(CUDA_CFLAGS) $(CUDA_PR) -DCUDA_MATRIX=$(CUDA_MATRIX_TYPE)

--- a/src/cuda/typedefs.hpp
+++ b/src/cuda/typedefs.hpp
@@ -21,11 +21,12 @@
 #include <thrust/iterator/constant_iterator.h>
 #include <thrust/iterator/zip_iterator.h>
 #include <thrust/tuple.h>
-#include <cusp/copy.h>
-#include <cusp/csr_matrix.h>
-#include <cusp/dia_matrix.h>
-#include <cusp/ell_matrix.h>
-#include <cusp/multiply.h>
+//#include <cusp/copy.h>
+//#include <cusp/csr_matrix.h>
+//#include <cusp/dia_matrix.h>
+//#include <cusp/ell_matrix.h>
+//#include <cusp/multiply.h>
+#include "cusparse.h"
 
 // Vampire headers
 #include "cuda.hpp"
@@ -48,10 +49,13 @@ namespace internal{
       typedef float cu_real_t;
    #endif
 
-   typedef cusp::array1d<cu_real_t, cusp::device_memory> cu_real_array_t;
-   typedef cusp::array1d<int, cusp::device_memory> cu_index_array_t;
+   //typedef cusp::array1d<cu_real_t, cusp::device_memory> cu_real_array_t;
+   //typedef cusp::array1d<int, cusp::device_memory> cu_index_array_t;
+   typedef thrust::device_vector<double> cu_real_array_t;
+   typedef thrust::device_vector<int>    cu_index_array_t;
 
    // Compile-time selectable matrix structure
+   /*
    #if CUDA_MATRIX == CSR
       typedef cusp::csr_matrix<int, cu_real_t, cusp::device_memory> cu_exch_mat_t;
    #elif CUDA_MATRIX == DIA
@@ -61,6 +65,8 @@ namespace internal{
    #else
       typedef cusp::csr_matrix<int, cu_real_t, cusp::device_memory> cu_exch_mat_t;
    #endif
+   */
+   typedef cusparseSpMatDescr_t cu_exch_mat_t;
 
    // struct for material parameters
    struct material_parameters_t {

--- a/tests/cuda/Co.mat
+++ b/tests/cuda/Co.mat
@@ -1,0 +1,29 @@
+#===================================================
+# Sample vampire material file V3+
+#===================================================
+
+#---------------------------------------------------
+# Number of Materials
+#---------------------------------------------------
+material:num-materials=2
+#---------------------------------------------------
+# Material 1 Cobalt Generic
+#---------------------------------------------------
+material[1]:material-name=Co
+material[1]:damping-constant=1.0
+material[1]:exchange-matrix[1]=1.12e-21
+material[1]:atomic-spin-moment=1.72 !muB
+material[1]:uniaxial-anisotropy-constant=1.0e-24
+material[1]:material-element=Ag
+material[1]:minimum-height=0.0
+material[1]:maximum-height=0.5
+material[1]:dmi-constant[2] = 4.0e-22
+material[1]:initial-spin-direction = 0.707,0.0,0.707
+#---------------------------------------------------
+# Material 2 Platinum Generic
+#---------------------------------------------------
+material[2]:material-name=Pt
+material[2]:material-element=Fe
+material[2]:minimum-height=0.5
+material[2]:maximum-height=1.0
+material[2]:non-magnetic = keep

--- a/tests/cuda/input
+++ b/tests/cuda/input
@@ -1,0 +1,62 @@
+#------------------------------------------
+# Sample vampire input file to perform
+# benchmark calculation for v4.0
+#
+#------------------------------------------
+
+#------------------------------------------
+# Creation attributes:
+#------------------------------------------
+create:crystal-structure=fcc
+
+create:periodic-boundaries-x
+create:periodic-boundaries-y
+#------------------------------------------
+# System Dimensions:
+#------------------------------------------
+dimensions:unit-cell-size = 3.54 !A
+dimensions:system-size-x = 10 !nm
+dimensions:system-size-y = 10 !nm
+dimensions:system-size-z = 0.7 !nm
+
+#------------------------------------------
+# Material Files:
+#------------------------------------------
+material:file=Co.mat
+
+#exchange:dmi-cutoff-range = 5.01 !A # sc
+exchange:dmi-cutoff-range = 3.55 !A # fcc
+
+#------------------------------------------
+# Simulation attributes:
+#------------------------------------------
+sim:equilibration-temperature = 100.0
+sim:equilibration-time-steps = 10
+sim:temperature=0.0
+sim:time-steps-increment=10
+sim:total-time-steps=20000
+sim:time-step=1.0E-15
+
+#------------------------------------------
+# Program and integrator details
+#------------------------------------------
+sim:program = time-series
+sim:integrator = llg-heun
+gpu:acceleration=off
+gpu:calculate-statistics-on-cpu=true
+
+
+#------------------------------------------
+# data output
+#------------------------------------------
+output:real-time
+output:temperature
+output:magnetisation
+output:magnetisation-length
+output:output-rate = 1000
+
+config:atoms
+config:atoms-output-rate = 100
+
+screen:time-steps
+screen:magnetisation-length


### PR DESCRIPTION
I have swapped out the older cusp sparse matrix vector routines for the cusparse generalised interface ones. It compiles and I get results matching the previous cusp implementation following the DMI test. There are still errors with the GPU stats calculation but with the `gpu:calculate-statistics-on-cpu=true` flag the magnetisation appears close to the CPU version.

![Vampire_CPU_GPU_cusparse](https://user-images.githubusercontent.com/12896508/70329722-f02b7500-1833-11ea-9204-62ff92c0a822.png)
