### PR TITLE
Fixed custom colourmap usage in vdc

### DIFF
--- a/util/vdc/command.cpp
+++ b/util/vdc/command.cpp
@@ -241,10 +241,13 @@ int command( int argc, char* argv[] ){
          vdc::x_axis_colour = true;
 
       }
-      else if ( sw == "--custom_colourmap" ){
+      else if ( sw == "--custom-colourmap" ){
 
          // check number of args not exceeded
          check_arg(arg, argc, argv, temp_str, "Error - expected custom colourmap name.");
+
+         // set colour_keyword to "custom" 
+         vdc::colour_keyword = "custom";
 
          // set custom map file name
          vdc::custom_colourmap_file = temp_str;


### PR DESCRIPTION
Changed underscore to hyphen in custom colourmap keyword "--custom-colourmap" and added a flag to use the provided colourmap. 