### PR TITLE
Vdc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,8 +96,11 @@ run/unit-cell-creator
 
 
 #----------------------------------------------
-# Vscode project files and folders
+# Vscode and Clang project files and folders
 #----------------------------------------------
 .vscode/
+.cache/
+.clang-tidy
 
+temp/*
 #EOF

--- a/manual/5-Visualization/Chapter.tex
+++ b/manual/5-Visualization/Chapter.tex
@@ -16,7 +16,7 @@ The \vampire data converter, or \vdc, is run to produce the input files needed. 
 \textit{vdc -{}-povray}
 \end{minipage}
 
-%opt/vampire/cfg2xx\\
+Note that all command line parameters passed to vdc are not case sensitive.
 
 \section*{Getting started}
 \phantomsection\addcontentsline{toc}{section}{Getting started}
@@ -86,7 +86,7 @@ For example, to render frame 9 only, you could use:
 
 \noindent where the "-W" and "-H" flags define the width and heigh of the image (the resolution), and "+A" is used for antialiasing.
 
-Output from \vdc can be customised in several ways by using a separate \vdc input file. The \vdc input file is a plain text file containing parameters and arguments which change the output behaviour. Comments can be included with the '\#' symbol and the special characters ' ,()\{\}[]:=!' can also be used but are ignored by \vdc.  By default this file is called \textit{vdc-input}, and is read automatically. To change the name of the \vdc input file, a command line parameter can be used:
+Output from \vdc can be customised in several ways, either by passing parameters to the command line (using the '\textit{--}' notation), or by using a separate \vdc input file. The \vdc input file is a plain text file containing parameters and arguments which change the output behaviour. This should be helpful when many parameters, or multiple vdc runs with the same parameters, are needed. Comments can be included with the '\#' symbol and the special characters ' ,()\{\}[]:=!' can also be used but are ignored by \vdc.  By default this file is called \textit{vdc-input}, and is read automatically. To change the name of the \vdc input file, a command line parameter can be used:
 
 \noindent
 \begin{minipage}[c]{\textwidth}
@@ -94,7 +94,7 @@ Output from \vdc can be customised in several ways by using a separate \vdc inpu
 \textit{vdc -{}-input-file [filename]}
 \end{minipage}
 
-There are many command line options that can be used to change all visualisation outputs including Rasmol, Jmol and POV-Ray. To get help with the usage of these parameters outside of the manual, it is also possible to print help messages from the command line by using the \textit{-h} or \textit{-{}-help} command line argument, followed by the name of a \textit{vdc-input} file parameter:
+There are many options that can be used to change all visualisation outputs including Rasmol, Jmol and POV-Ray. To get help with the usage of these parameters outside of the manual, it is also possible to print help messages from the command line by using the \textit{-h} or \textit{-{}-help} command line argument, followed by the name of a \textit{vdc-input} file parameter:
 
 \noindent
 \begin{minipage}[c]{\textwidth}

--- a/util/vdc/data.cpp
+++ b/util/vdc/data.cpp
@@ -39,6 +39,9 @@ namespace vdc{
    bool x_axis_colour = false;
    bool default_camera_pos = true;
 
+   // list of input file parameters set in command line (to check for double usage)
+   std::vector<std::string> cmdl_parameters;
+
    format_t format;
 
    uint64_t num_atoms = 0;

--- a/util/vdc/functions.cpp
+++ b/util/vdc/functions.cpp
@@ -605,27 +605,25 @@ void arg_count(const input_t &input, size_t args_required, std::string requireme
    const size_t &num_args = input.value.size();
    std::string many_or_few;
 
+   // location message for input file or command line parameters
+   std::string location_message;
+   if (input.line_number == -1){ location_message = "' passed in the command line\n"; }
+   else { location_message = "' on line " + std::to_string(input.line_number) + " of input file '" + vdc::input_file + "'\n"; } 
+
    if (requirement == "eq"){
       if (num_args == args_required){ return; }
       else {
-         std::cerr << "Error - expected " << args_required << " arguments in " << input.key
-                   << "' on line " << input.line_number << " of input file '" << vdc::input_file
-                   << "'\nInstead got " << num_args << ".\n"; 
+         std::cerr << "Error - expected " << args_required << " arguments in '" << input.key
+                   << location_message << "\nInstead got " << num_args << ".\n"; 
       }
    }
    else if (requirement == "ge"){
       if (num_args >= args_required){ return; }
-      else {
-         std::cerr << "Error - too few arguments passed to '" << input.key << "' on line "
-                   << input.line_number << " of input file '" << vdc::input_file << "'\n";
-      }
+      else { std::cerr << "Error - too few arguments passed to '" << input.key << location_message; }
    }
    else if (requirement == "le"){
       if (num_args <= args_required){ return; }
-      else {
-         std::cerr << "Error - too many arguments passed to '" << input.key << "' on line "
-                   << input.line_number << " of input file '" << vdc::input_file << "'\n";
-      }
+      else { std::cerr << "Error - too many arguments passed to '" << input.key << location_message; }
    }
    else {
       std::cerr << "Bad requirement: " << requirement << std::endl;
@@ -637,8 +635,13 @@ void arg_count(const input_t &input, size_t args_required, std::string requireme
 
 // output error message and exit
 void error_message(const input_t &input, std::string message){
-   std::cerr << "Error - " << message << " in '" << input.key << "' on line "
-             << input.line_number << " of input file '" << vdc::input_file << "'\n";
+
+   // location message for input file or command line parameters
+   std::string location_message;
+   if (input.line_number == -1){ location_message = "' passed in the command line\n"; }
+   else { location_message = "' on line " + std::to_string(input.line_number) + " of input file '" + vdc::input_file + "'\n"; }
+
+   std::cerr << "Error - " << message << " in '" << input.key << location_message;
    
    std::exit(EXIT_FAILURE);
 }

--- a/util/vdc/functions.cpp
+++ b/util/vdc/functions.cpp
@@ -614,7 +614,7 @@ void arg_count(const input_t &input, size_t args_required, std::string requireme
       if (num_args == args_required){ return; }
       else {
          std::cerr << "Error - expected " << args_required << " arguments in '" << input.key
-                   << location_message << "\nInstead got " << num_args << ".\n"; 
+                   << location_message << "Instead got " << num_args << "\n"; 
       }
    }
    else if (requirement == "ge"){

--- a/util/vdc/read.cpp
+++ b/util/vdc/read.cpp
@@ -15,7 +15,7 @@
 #include<fstream>
 #include<locale>
 #include<cctype>
-
+#include<algorithm>
 
 // vdc headers
 #include"vdc.hpp"
@@ -68,7 +68,6 @@ void read(std::vector<input_t> &input_list){
 
    // temp variables
    std::string temp_val;
-   std::vector<std::string> temp_vector;
 
    // work through input_file
    while(std::getline(input_file,line)){
@@ -107,9 +106,7 @@ void read(std::vector<input_t> &input_list){
             temp_val.clear();
          }
          // otherwise add char to temp_val
-         else {
-            temp_val.push_back(c);
-         }
+         else { temp_val.push_back(c); }
       }
 
       // push back last value if not empty
@@ -124,7 +121,6 @@ void read(std::vector<input_t> &input_list){
       // add to input_list and empty temp storage
       input.line_number = line_number;
       input_list.push_back(input);
-      temp_vector.clear();
       temp_val.clear();
       line_number++;
    }
@@ -139,6 +135,14 @@ void set(const std::vector<input_t> &input_list){
 
    // loop through input lines
    for (const input_t &input : input_list){
+
+      // if key has already been set at command line, print warning and skip
+      if (std::find(vdc::cmdl_parameters.begin(), vdc::cmdl_parameters.end(), input.key) != vdc::cmdl_parameters.end() ){
+         std::cerr << "Warning - the parameter '" << input.key << "' has been set in the command line\n"
+                   << "The same parameter on line " << input.line_number << " of input file '" << vdc::input_file
+                   << "' is being ignored\n";
+         continue;
+      }
 
       // check key, print error if not found
       if (vdc::key_list.find(input.key) == vdc::key_list.end()){

--- a/util/vdc/vdc.hpp
+++ b/util/vdc/vdc.hpp
@@ -49,6 +49,9 @@ namespace vdc{
    enum slice_type{ box, box_void, sphere, cylinder};
    extern format_t format;
 
+   // list of input file parameters set in command line (to check for double usage)
+   extern std::vector<std::string> cmdl_parameters;
+
    // simple struct to store material parameters
    struct material_t{
       int id;
@@ -61,7 +64,7 @@ namespace vdc{
    struct input_t{
       std::string key;
       std::vector<std::string> value;
-      unsigned int line_number;
+      int line_number;
    };
 
    // struct to hold slice information


### PR DESCRIPTION
**Reintroduced command line parameters to vdc**

With the aim of being a secondary method for using input parameters, parameters normally used only in the vdc input file can now also be used in the command line, with a few rules. The _VAMPIRE_ manual has been updated to reflect this change. 

Parameters passed to the command line must use "--" notation. Aside from this, vdc is very lenient with usage of special characters, uppercase letters or spaces used in the parameter or following arguments, as in the vdc input file. If multiple parameters are used in the command line (not recommended, as this is the main use of the input file), order does not matter.

In general, the same parameters should not be repeated in the command line and vdc input. If this occurs, parameters passed in the command line take precedence and a warning message is shown. This does not affect slice parameters, which are specifically allowed to be defined multiple times. 

Spelling errors, unknown parameters or incorrect arguments passed in the command line halt the program and produce an error which states that the errors are in the command line parameters.
