### PR TITLE
Binder Cumulant added to develop branch, for calculation of Tc

### DIFF
--- a/hdr/stats.hpp
+++ b/hdr/stats.hpp
@@ -81,9 +81,13 @@ namespace stats
 	extern bool calculate_grain_susceptibility;
 	extern bool calculate_material_susceptibility;
 
+        extern bool calculate_system_binder_cumulant;
+        extern bool calculate_material_binder_cumulant;
+
 	// forward declaration of friend classes
 	class susceptibility_statistic_t;
 	class specific_heat_statistic_t;
+        class binder_cumulant_statistic_t;
 
 	class standard_deviation_statistic_t;
    //----------------------------------
@@ -156,6 +160,7 @@ namespace stats
 
       friend class susceptibility_statistic_t;
       friend class standard_deviation_statistic_t;
+      friend class binder_cumulant_statistic_t;
       public:
          magnetization_statistic_t (std::string n):initialized(false){
            name = n;
@@ -306,7 +311,29 @@ namespace stats
          std::string name;
 
    };
+   //----------------------------------
+   // Binder cumulant Class definition
+   //----------------------------------
+   class binder_cumulant_statistic_t{
 
+      public:
+         binder_cumulant_statistic_t (std::string n):initialized(false){
+           name = n;
+         };
+         void initialize(magnetization_statistic_t& mag_stat);
+         void calculate(const std::vector<double>& magnetization);
+         void reset_averages();
+         std::string output_binder_cumulant(bool header);
+
+      private:
+         bool initialized;
+         int num_elements;
+         double mean_counter;
+         std::vector<double> binder_cumulant_squared;
+         std::vector<double> binder_cumulant_fourth_power;
+         std::string name;
+
+   };
 
    //----------------------------------
 	// Statistics class instantiations
@@ -334,6 +361,9 @@ namespace stats
    extern susceptibility_statistic_t material_susceptibility;
 
    extern standard_deviation_statistic_t material_standard_deviation;
+
+   extern binder_cumulant_statistic_t system_binder_cumulant;
+   extern binder_cumulant_statistic_t material_binder_cumulant;
 
 }
 

--- a/src/statistics/binder_cumulant.cpp
+++ b/src/statistics/binder_cumulant.cpp
@@ -1,0 +1,143 @@
+//-----------------------------------------------------------------------------
+//
+// This source file is part of the VAMPIRE open source package under the
+// GNU GPL (version 2) licence (see licence file for details).
+//
+// (c) R F L Evans 2014. All rights reserved.
+//
+//-----------------------------------------------------------------------------
+
+// C++ standard library headers
+#include <algorithm>
+#include <cmath>
+#include <iostream>
+#include <sstream>
+#include <string>
+// Vampire headers
+#include "errors.hpp"
+#include "stats.hpp"
+#include "vmpi.hpp"
+#include "vio.hpp"
+
+namespace stats{
+
+//------------------------------------------------------------------------------------------------------
+// Constructor
+//------------------------------------------------------------------------------------------------------
+//binder_cumulant_statistic_t::binder_cumulant_statistic_t (){}
+
+//------------------------------------------------------------------------------------------------------
+// Function to initialize data structures
+//------------------------------------------------------------------------------------------------------
+void binder_cumulant_statistic_t::initialize(stats::magnetization_statistic_t& mag_stat) {
+
+   // Check that magnetization statistic is properly initialized
+   if(!mag_stat.is_initialized()){
+      terminaltextcolor(RED);
+      std::cerr << "Programmer Error - Uninitialized magnetization statistic passed to binder cumulant statistic - please initialize first." << std::endl;
+      terminaltextcolor(WHITE);
+      zlog << zTs() << "Programmer Error - Uninitialized magnetization statistic passed to binder cumulant statistic - please initialize first." << std::endl;
+      err::vexit();
+   }
+
+   // Determine number of magnetization statistics*4
+   std::vector<double> temp = mag_stat.get_magnetization();
+   num_elements = temp.size()/4;
+
+   // Now set number of binder cumulant values to match
+   binder_cumulant_squared.resize(num_elements,0.0);
+   binder_cumulant_fourth_power.resize(num_elements,0.0);
+
+   // initialize mean counter
+   mean_counter = 0.0;
+
+   // Set flag indicating correct initialization
+   initialized=true;
+
+}
+
+//------------------------------------------------------------------------------------------------------
+// Function to calculate binder cumulant of the magnetisation and retain the mean value
+//
+//       V_L =          <m_l^4>
+//             1  -  -------------
+//                    3*<m_l^2>^2
+//
+//       m_l = sum_i mu_i S_i
+//             --------------
+//               sum_i mu_i
+//
+//-------------------------------------------------------------------------------------------------------
+void binder_cumulant_statistic_t::calculate(const std::vector<double>& magnetization){
+
+   // loop over all elements
+   for(int id=0; id< num_elements; ++id){
+
+      // copy reduced magnetisation
+      const double mm = magnetization[4*id + 3];
+
+      binder_cumulant_squared[id]+=mm*mm;
+      binder_cumulant_fourth_power[id]+=mm*mm*mm*mm;
+
+   }
+
+   mean_counter+=1.0;
+
+   return;
+
+}
+
+//------------------------------------------------------------------------------------------------------
+// Function to reset statistical averages
+//------------------------------------------------------------------------------------------------------
+void binder_cumulant_statistic_t::reset_averages(){
+
+   // reinitialise mean magnetization to zero
+   std::fill(binder_cumulant_squared.begin(),binder_cumulant_squared.end(),0.0);
+   std::fill(binder_cumulant_fourth_power.begin(),binder_cumulant_fourth_power.end(),0.0);
+
+   // reset data counter
+   mean_counter = 0.0;
+
+   return;
+
+}
+
+//------------------------------------------------------------------------------------------------------
+// Function to output mean binder cumulant values as string
+//------------------------------------------------------------------------------------------------------
+std::string binder_cumulant_statistic_t::output_binder_cumulant(bool header){
+
+   // result string stream
+   std::ostringstream res;
+
+   // set custom precision if enabled
+   if(vout::custom_precision){
+      res.precision(vout::precision);
+      if(vout::fixed) res.setf( std::ios::fixed, std::ios::floatfield );
+   }
+   vout::fixed_width_output result(res,vout::fw_size); 
+   if(!header){
+
+   // determine inverse mean counter and its square
+   const double imean_counter = 1.0/mean_counter;
+   const double imean_counter_sq = 1.0/(mean_counter*mean_counter);
+
+   // loop over all elements
+   for(int id=0; id< num_elements - 1; ++id){ // ignore last element as always contains non-magnetic atoms
+
+      const double bc = 1 - binder_cumulant_fourth_power[id]*imean_counter/(3.0*binder_cumulant_squared[id]*binder_cumulant_squared[id]*imean_counter_sq);
+
+      result << bc;
+
+   }
+   }else{
+       for(int id=0; id< num_elements - 1; ++id){ // ignore last element as always contains non-magnetic atoms
+          result << name + std::to_string(id) + "_bc";
+       }
+   }
+   return result.str();
+
+}
+
+} // end of namespace stats

--- a/src/statistics/data.cpp
+++ b/src/statistics/data.cpp
@@ -40,6 +40,9 @@ namespace stats{
    bool calculate_grain_susceptibility          = false;
    bool calculate_material_susceptibility       = false;
 
+   bool calculate_system_binder_cumulant        = false;
+   bool calculate_material_binder_cumulant      = false;
+
    energy_statistic_t system_energy("s");
    energy_statistic_t grain_energy("g");
    energy_statistic_t material_energy("m");
@@ -63,6 +66,9 @@ namespace stats{
    susceptibility_statistic_t system_susceptibility("s");
    susceptibility_statistic_t grain_susceptibility("g");
    susceptibility_statistic_t material_susceptibility("m");
+
+   binder_cumulant_statistic_t system_binder_cumulant("s");
+   binder_cumulant_statistic_t material_binder_cumulant("s");
 
    //-----------------------------------------------------------------------------
    // Shared variables used for statistics calculation

--- a/src/statistics/initialize.cpp
+++ b/src/statistics/initialize.cpp
@@ -219,6 +219,12 @@ namespace stats{
       if(stats::calculate_grain_susceptibility)    stats::grain_susceptibility.initialize(stats::grain_magnetization);
       if(stats::calculate_material_susceptibility) stats::material_susceptibility.initialize(stats::material_magnetization);
 
+      //------------------------------------------------------------------------
+      // binder cumulant
+      //------------------------------------------------------------------------
+      if(stats::calculate_system_binder_cumulant) stats::system_binder_cumulant.initialize(stats::system_magnetization);
+      if(stats::calculate_material_binder_cumulant) stats::material_binder_cumulant.initialize(stats::material_magnetization);
+
       return;
 
    }

--- a/src/statistics/makefile
+++ b/src/statistics/makefile
@@ -13,6 +13,7 @@ specific_heat.o \
 standard_deviation.o\
 reset.o \
 susceptibility.o \
+binder_cumulant.o\
 torque.o \
 update.o
 

--- a/src/statistics/reset.cpp
+++ b/src/statistics/reset.cpp
@@ -58,6 +58,10 @@ namespace stats{
          if(stats::calculate_grain_susceptibility)    stats::grain_susceptibility.reset_averages();
          if(stats::calculate_material_susceptibility) stats::material_susceptibility.reset_averages();
 
+         // reset binder cumulant statistics
+         if(stats::calculate_system_binder_cumulant)   stats::system_binder_cumulant.reset_averages();
+         if(stats::calculate_material_binder_cumulant) stats::material_binder_cumulant.reset_averages();
+
       }
 
       return;

--- a/src/statistics/update.cpp
+++ b/src/statistics/update.cpp
@@ -76,6 +76,10 @@ namespace stats{
             if(stats::calculate_system_susceptibility)        stats::system_susceptibility.calculate(stats::system_magnetization.get_magnetization());
             if(stats::calculate_grain_susceptibility)         stats::grain_susceptibility.calculate(stats::grain_magnetization.get_magnetization());
             if(stats::calculate_material_susceptibility)      stats::material_susceptibility.calculate(stats::material_magnetization.get_magnetization());
+            
+            // update binder cumulant statistics
+            if(stats::calculate_system_binder_cumulant)         stats::system_binder_cumulant.calculate(stats::system_magnetization.get_magnetization());
+            if(stats::calculate_material_binder_cumulant)       stats::material_binder_cumulant.calculate(stats::material_magnetization.get_magnetization());
 
          }
 

--- a/src/vio/datalog.cpp
+++ b/src/vio/datalog.cpp
@@ -283,6 +283,12 @@ namespace vout{
 				break;
 			case 72:
 			   vout::fractional_electric_field_strength(stream, header);
+                        case 997: //MP
+      		                vout::material_binder_cumulant(stream,header);
+      		                break;
+      	                case 998:
+      		                vout::system_binder_cumulant(stream,header);
+      		                break;
 			case 999: //AJN
 				vout::standard_deviation(stream,header);
 				break;

--- a/src/vio/internal.hpp
+++ b/src/vio/internal.hpp
@@ -120,6 +120,7 @@ namespace vout{
    void material_torque(std::ostream& stream, bool header);
    void standard_deviation(std::ostream& stream,bool header);
    void mean_system_susceptibility(std::ostream& stream,bool header);
+   void system_binder_cumulant(std::ostream& stream,bool header);
    void phonon_temperature(std::ostream& stream,bool header);
    void material_temperature(std::ostream& stream,bool header);
    void material_applied_field_strength(std::ostream& stream,bool header);
@@ -153,6 +154,7 @@ namespace vout{
 	void mean_mvec(std::ostream& stream,bool header);
 	void mat_mean_mvec(std::ostream& stream,bool header);
    void mean_material_susceptibility(std::ostream& stream,bool header);
+   void material_binder_cumulant(std::ostream& stream,bool header);
    void mean_height_magnetisation_length(std::ostream& stream,bool header);
    void mean_height_magnetisation(std::ostream& stream,bool header);
 

--- a/src/vio/match.cpp
+++ b/src/vio/match.cpp
@@ -1197,6 +1197,24 @@ namespace vin{
             return EXIT_SUCCESS;
         }
         //-------------------------------------------------------------------
+        test="binder-cumulant";
+        if(word==test){
+            // Set flags for calculations of binder cumulant and magnetization
+            stats::calculate_system_binder_cumulant=true;
+            stats::calculate_system_magnetization=true;
+            output_list.push_back(998);
+            return EXIT_SUCCESS;
+        }
+        //-------------------------------------------------------------------
+        test="material-binder-cumulant";
+        if(word==test){
+            // Set flags for calculations of binder cumulant and magnetization
+            stats::calculate_material_binder_cumulant=true;
+            stats::calculate_material_magnetization=true;
+            output_list.push_back(997);
+            return EXIT_SUCCESS;
+        }
+        //-------------------------------------------------------------------
         test="electron-temperature"; // identical to temperature
         if(word==test){
             output_list.push_back(2);

--- a/src/vio/outputfunctions.cpp
+++ b/src/vio/outputfunctions.cpp
@@ -189,6 +189,11 @@ namespace vout{
       stream << stats::system_susceptibility.output_mean_susceptibility(sim::temperature,header);
    }
 
+    // Output Function 998 - with Header
+   void system_binder_cumulant(std::ostream& stream, bool header){
+      stream << stats::system_binder_cumulant.output_binder_cumulant(header);
+   }
+
    // Output Function 999 - with Header
    void standard_deviation(std::ostream& stream, bool header){
       stream << stats::material_standard_deviation.output_standard_deviation(header);
@@ -373,6 +378,11 @@ namespace vout{
    void mean_material_susceptibility(std::ostream& stream, bool header){
 		stream << stats::material_susceptibility.output_mean_susceptibility(sim::temperature,header);
 	}
+
+   // Output Function 997 - with Header
+   void material_binder_cumulant(std::ostream& stream, bool header){
+		stream << stats::material_binder_cumulant.output_binder_cumulant(header);
+   }
 
 	// Output Function 51 - with Header
    void mean_height_magnetisation_length(std::ostream& stream, bool header){


### PR DESCRIPTION
 Changes to be committed:
	modified:   hdr/stats.hpp
	new file:   src/statistics/binder_cumulant.cpp
	modified:   src/statistics/data.cpp
	modified:   src/statistics/initialize.cpp
	modified:   src/statistics/makefile
	modified:   src/statistics/reset.cpp
	modified:   src/statistics/update.cpp
	modified:   src/vio/datalog.cpp
	modified:   src/vio/internal.hpp
	modified:   src/vio/match.cpp
	modified:   src/vio/outputfunctions.cpp
	
It is hard to find Tc for a material since it changes with the size of the system, but the 4th order binder cumulant can be written as a function of the ratio L/xi, where L is the size of the system and xi is the correlation length. Independent of L, this ratio is zero at Tc since the correlation length diverges. Therefore, the Tc can be found by simulating systems of different size and seeing where the binder cumulants from these different simulations intersect.

The formula is
U_L = 1 - <M^4>/(3*<M^2>^2)
and this **implementation in Vampire follows that of the susceptibility very closely**.

There is both system wide binder cumulant, and material specific binder cumulant, specified in the input file with:
output:binder-cumulant
output:material-binder-cumulant

The attached image shows the binder cumulant included into the Curie temperature tutorial simulation on the Vampire website. A smaller temperature step is used, and near/above Tc the number of time steps is increased and simulations are repeated for an average.

![tutorialExample_binderCumulant](https://user-images.githubusercontent.com/55807898/165315462-e9f4b6bf-e1a2-44ed-a19c-2c38b7429c05.png)