### PR TITLE
Move saving of old spin configurations for spin pumping calculation

### DIFF
--- a/hdr/spinpumping.hpp
+++ b/hdr/spinpumping.hpp
@@ -1,0 +1,82 @@
+//------------------------------------------------------------------------------
+//
+//   This file is part of the VAMPIRE open source package under the
+//   Free BSD licence (see licence file for details).
+//
+//   (c) Richard F L Evans 2019. All rights reserved.
+//
+//------------------------------------------------------------------------------
+//
+
+#ifndef SPINPUMPING_H_
+#define SPINPUMPING_H_
+
+// C++ standard library headers
+#include <string>
+#include <vector>
+
+// Vampire headers
+#include "create.hpp"
+#include "spinpumping.hpp"
+
+//--------------------------------------------------------------------------------
+// Namespace for variables and functions for spinpumping module
+//--------------------------------------------------------------------------------
+namespace spin_pumping{
+
+   //-----------------------------------------------------------------------------
+   // Shared variables for data output
+   //-----------------------------------------------------------------------------
+
+   // extern std::vector <double> x_s_cross_dsdt_array;        // arrays to store cross product between spin and time derivative of spins
+   // extern std::vector <double> y_s_cross_dsdt_array;        // arrays to store cross product between spin and time derivative of spins
+   // extern std::vector <double> z_s_cross_dsdt_array;        // arrays to store cross product between spin and time derivative of spins
+
+   //-----------------------------------------------------------------------------
+   // Function to initialise spinpumping module
+   //-----------------------------------------------------------------------------
+   void initialize(const double system_size_x, // maximum dimensions of system along x-direction (angstroms)
+                   const double system_size_y, // maximum dimensions of system along y-direction (angstroms)
+                   const double system_size_z, // maximum dimensions of system along z-direction (angstroms)
+                   const int num_materials,    // number of materials
+                   const uint64_t num_atoms,   // number of atoms
+                   const std::vector<int>& atoms_type_array, // material types of atoms
+                   const std::vector<double>& atoms_x_coord_array, // x-coordinates of atoms
+                   const std::vector<double>& atoms_y_coord_array, // y-coordinates of atoms
+                   const std::vector<double>& atoms_z_coord_array, // z-coordinates of atoms
+                   const std::vector<double>& atoms_m_spin_array,  // moments of atoms (muB)
+                   const std::vector<double>& material_damping_array, // array of material level damping constants
+                   const std::vector<bool>& is_magnetic_material, // array of size num_mat to state whether material is magnetic (true) or not (false)
+                   const std::vector<cs::nm_atom_t> non_magnetic_atoms_array // list of non-magnetic atoms
+   );
+
+   //-----------------------------------------------------------------------------
+   // Function to update resistance, current and spin transfer torque fields
+   //-----------------------------------------------------------------------------
+   void update(const unsigned int num_local_atoms,            // number of local atoms
+               const uint64_t time_sim,                       // simulation time
+               const std::vector<double>& atoms_x_spin_array, // x-spin vector of atoms
+               const std::vector<double>& atoms_y_spin_array, // y-spin vector of atoms
+               const std::vector<double>& atoms_z_spin_array, // z-spin-vector of atoms
+               const std::vector<double>& atoms_m_spin_array);
+
+   void calculate_field(const unsigned int start_index,            // first atom
+                        const unsigned int end_index,              // last atom
+                        std::vector<double>& atoms_x_field_array,  // x-field of atoms
+                        std::vector<double>& atoms_y_field_array,  // y-field of atoms
+                        std::vector<double>& atoms_z_field_array); // z-field of atoms
+
+   //---------------------------------------------------------------------------
+   // Function to process input file parameters for spinpumping module
+   //---------------------------------------------------------------------------
+   bool match_input_parameter(std::string const key, std::string const word, std::string const value, std::string const unit, int const line);
+
+   //---------------------------------------------------------------------------
+   // Function to process material parameters
+   //---------------------------------------------------------------------------
+   bool match_material_parameter(std::string const word, std::string const value, std::string const unit, int const line, int const super_index, const int sub_index);
+
+
+} // end of spin_pumping namespace
+
+#endif //SPINPUMPING_H_

--- a/src/simulate/increment_time.cpp
+++ b/src/simulate/increment_time.cpp
@@ -67,10 +67,14 @@ void increment_time(){
                           atoms::m_spin_array);
 
    spin_pumping::update(num_local_atoms,
+                          sim::time,
                           atoms::x_spin_array,
                           atoms::y_spin_array,
                           atoms::z_spin_array,
                           atoms::m_spin_array);
+
+	// If spin-pumping enabled, Store old spin configuration 
+	if(sim::compute_time_derivative) atoms::store_old_spins();
 
    return;
 

--- a/src/simulate/sim.cpp
+++ b/src/simulate/sim.cpp
@@ -661,9 +661,6 @@ void integrate_serial(uint64_t n_steps){
       case 0: // LLG Heun
          for(uint64_t ti=0;ti<n_steps;ti++){
 
-            // Store old spin configuration if computation of spin-pumping enabled
-            if(sim::compute_time_derivative) atoms::store_old_spins();
-
             // Optionally select GPU accelerated version
             if(gpu::acceleration) gpu::llg_heun();
             // Otherwise use CPU version
@@ -770,9 +767,6 @@ int integrate_mpi(uint64_t n_steps){
 		case 0: // LLG Heun
 			for(uint64_t ti=0;ti<n_steps;ti++){
 						  
-            // Store old spin configuration if computation of spin-pumping enabled
-            if(sim::compute_time_derivative) atoms::store_old_spins();
-
 			#ifdef MPICF
 				// Select CUDA version if supported
 				#ifdef CUDA

--- a/src/spinpumping/internal.hpp
+++ b/src/spinpumping/internal.hpp
@@ -133,6 +133,7 @@ namespace spin_pumping{
       // Function to compute atomistic spin pumping as : s_i x ds_i/dt
       //---------------------------------------------------------------------------
       void calculate_spin_pumping(const unsigned int num_local_atoms,            // number of local atoms
+                           const uint64_t time_sim,                              // simulation time
                            const std::vector<double>& atoms_x_spin_array, // x-spin vector of atoms
                            const std::vector<double>& atoms_y_spin_array, // y-spin vector of atoms
                            const std::vector<double>& atoms_z_spin_array, // z-spin-vector of atoms

--- a/src/spinpumping/output_atomistic_spin_pumping.cpp
+++ b/src/spinpumping/output_atomistic_spin_pumping.cpp
@@ -85,11 +85,10 @@ namespace spin_pumping{
          mean_y = mean_y / double (total_num_atoms);
          mean_z = mean_z / double (total_num_atoms);
 
-         // output data to file atomistic_spin_current_positions.txt
          if(vmpi::master){
             std::ofstream ofile;
             std::stringstream filename;
-            filename << "atomistic-spin-current-positions.cfg";
+            filename << "atomistic-spin-pumping-positions.cfg";
             zlog << zTs() << "Outputting atomistic coordinates for spin pumping to file " << filename.str() << std::endl;
             ofile.open(std::string(filename.str()).c_str());
 
@@ -125,7 +124,7 @@ namespace spin_pumping{
 
          // check for initialised data structures
          if(!output_atomistic_spin_pumping_initialised){
-            std::cerr << "Programmer error : spin_pumping::output_atomistic_spin_current_initialised() called before initialisation" << std::endl;
+            std::cerr << "Programmer error : spin_pumping::output_atomistic_spin_pumping_initialised() called before initialisation" << std::endl;
             err::vexit();
          }
 
@@ -145,15 +144,13 @@ namespace spin_pumping{
          // collate global data on master
          vmpi::fast_collate(data_from_local_atoms, data_from_all_atoms, counts, displacements);
 
-         // output data to file atomistic_spin_current_field.txt
          if(vmpi::master){
             std::ofstream ofile;
             std::stringstream filename;
-            filename << "atomistic-spin-current-" << std::setfill ('0') << std::setw (8) << config_file_counter << ".cfg";
+            filename << "atomistic-spin-pumping-" << std::setfill ('0') << std::setw (8) << config_file_counter << ".cfg";
             zlog << zTs() << "Outputting spin pumping data to file " << filename.str() << std::endl;
             ofile.open(std::string(filename.str()).c_str());
 
-            // ofile.open("atomistic_spin_current.txt");
             for(int atom = 0; atom < total_num_atoms; atom++){
                ofile << data_from_all_atoms[ 3 * atom + 0 ] << "\t" <<
                         data_from_all_atoms[ 3 * atom + 1 ] << "\t" <<

--- a/src/spinpumping/spin_pumping.cpp
+++ b/src/spinpumping/spin_pumping.cpp
@@ -27,6 +27,7 @@ namespace spin_pumping{
    	// Function to compute atomistic spin pumping as: s_i x ds_i/dt
    	//---------------------------------------------------------------------------
 		void calculate_spin_pumping(const unsigned int num_local_atoms,            // number of local atoms
+		                                  const uint64_t time_sim, 						// simulation time 
 		                                  const std::vector<double>& atoms_x_spin_array, // x-spin vector of atoms
 		                                  const std::vector<double>& atoms_y_spin_array, // y-spin vector of atoms
 		                                  const std::vector<double>& atoms_z_spin_array, // z-spin-vector of atoms
@@ -35,6 +36,12 @@ namespace spin_pumping{
 		                                  const std::vector<double>& atoms_z_old_spin_array, // old z-spin-vector of atoms
 		                                  const std::vector<double>& atoms_m_spin_array  // moment of atoms
 		                               ){
+
+				//-------------------------------------------------------------------------
+				// check that is not first step - if not do nothing
+				//-------------------------------------------------------------------------
+				if( time_sim-1<1 ){return;}
+
 				// Arrays to store calculation ds/dt
 				std::vector <double> x_dsdt_array(num_local_atoms,0.0);
 				std::vector <double> y_dsdt_array(num_local_atoms,0.0);

--- a/src/spinpumping/update.cpp
+++ b/src/spinpumping/update.cpp
@@ -25,6 +25,7 @@ namespace spin_pumping{
 // Function to update spin torque field
 //---------------------------------------------------------------------------------------------------------
 void update(const unsigned int num_local_atoms,            // number of local atoms
+            const uint64_t time_sim,                       // simulation time 
             const std::vector<double>& atoms_x_spin_array, // x-spin vector of atoms
             const std::vector<double>& atoms_y_spin_array, // y-spin vector of atoms
             const std::vector<double>& atoms_z_spin_array, // z-spin-vector of atoms
@@ -59,10 +60,9 @@ void update(const unsigned int num_local_atoms,            // number of local at
    const std::vector <double> atoms_x_old_spin_array = spin_pumping::internal::get_old_spins_x(num_local_atoms);
    const std::vector <double> atoms_y_old_spin_array = spin_pumping::internal::get_old_spins_y(num_local_atoms);
    const std::vector <double> atoms_z_old_spin_array = spin_pumping::internal::get_old_spins_z(num_local_atoms);
-   spin_pumping::internal::calculate_spin_pumping(num_local_atoms, atoms_x_spin_array, atoms_y_spin_array,
+   spin_pumping::internal::calculate_spin_pumping(num_local_atoms, time_sim, atoms_x_spin_array, atoms_y_spin_array,
                                                    atoms_z_spin_array, atoms_x_old_spin_array, atoms_y_old_spin_array,
                                                    atoms_z_old_spin_array, atoms_m_spin_array);
-
 
    //---------------------------------------------------------------------------------------------------------
    // calculate cells spin pumping


### PR DESCRIPTION
Move saving of old spin configurations for spin pumping calculation in increment_time() function.
Add spin pumping header file forgotten in previous commit. 
Rename spin-pumping output files.